### PR TITLE
fix usage of software encoders from webrtc library

### DIFF
--- a/webrtc-dotnet/GlobalOptions.cs
+++ b/webrtc-dotnet/GlobalOptions.cs
@@ -16,6 +16,8 @@ namespace WonderMediaProductions.WebRtc
         public bool LogToStandardError = true;
         public bool LogToDebugOutput = false;
 
+        public int StartBitrate = 0;
+
         public bool IsSingleThreaded
         {
             set => UseSignalingThread = UseWorkerThread = value;

--- a/webrtc-dotnet/Native.cs
+++ b/webrtc-dotnet/Native.cs
@@ -82,7 +82,8 @@ namespace WonderMediaProductions.WebRtc
             bool logToStdErr,
             bool logToDebug,
             LoggingCallback loggingCallback,
-            int minimumLoggingSeverity);
+            int minimumLoggingSeverity,
+            int startBitrate);
 
         [DllImport(DllPath, CallingConvention = CallingConvention.Cdecl)]
         internal static extern bool Shutdown();

--- a/webrtc-dotnet/PeerConnection.cs
+++ b/webrtc-dotnet/PeerConnection.cs
@@ -10,6 +10,8 @@ namespace WonderMediaProductions.WebRtc
     {
         private static int g_LastId;
 
+        private static GlobalOptions _options;
+
         // ReSharper disable NotAccessedField.Local
         private readonly Native.AudioBusReadyCallback _audioBusReadyDelegate;
         private readonly Native.DataAvailableCallback _dataAvailableDelegate;
@@ -33,6 +35,8 @@ namespace WonderMediaProductions.WebRtc
         /// </summary>
         public static void Configure(GlobalOptions options)
         {
+            Debug.Assert(_options == null);
+            _options = options;
             Native.Check(Native.Configure(
                 options.UseSignalingThread,
                 options.UseWorkerThread,
@@ -43,7 +47,8 @@ namespace WonderMediaProductions.WebRtc
                 options.LogToStandardError,
                 options.LogToDebugOutput,
                 options.MinimumLogLevel != TraceLevel.Off ? OnMessageLogged : null,
-                4 - (int)(options.MinimumLogLevel)
+                4 - (int)(options.MinimumLogLevel),
+                options.StartBitrate
                 ));
         }
 
@@ -72,7 +77,8 @@ namespace WonderMediaProductions.WebRtc
         /// </summary>
         public static bool HasFactory => Native.HasFactory();
 
-        public static bool SupportsHardwareTextureEncoding => Native.CanEncodeHardwareTextures();
+        public static bool SupportsHardwareTextureEncoding => Native.CanEncodeHardwareTextures() &&
+                                                              _options?.ForceSoftwareVideoEncoder != true;
 
         public PeerConnection(PeerConnectionOptions options)
         {

--- a/webrtc-native/PeerConnection.cpp
+++ b/webrtc-native/PeerConnection.cpp
@@ -453,6 +453,14 @@ int PeerConnection::AddVideoTrack(const std::string& label, int min_bps, int max
     return id;
 }
 
+bool PeerConnection::SetBitrate(const webrtc::BitrateSettings& bitrate)
+{
+    if (!peer_connection_)
+        return false;
+    peer_connection_->SetBitrate(bitrate);
+    return true;
+}
+
 bool PeerConnection::AddDataChannel(const char* label, bool is_ordered, bool is_reliable)
 {
     struct webrtc::DataChannelInit init;

--- a/webrtc-native/PeerConnection.h
+++ b/webrtc-native/PeerConnection.h
@@ -29,6 +29,7 @@ public:
 
     // TODO: Allow the user to select the kind of stream (what camera, etc...)
     int AddVideoTrack(const std::string& label, int min_bps, int max_bps, int max_fps);
+    bool SetBitrate(const webrtc::BitrateSettings& bitrate);
     bool SendVideoFrame(int video_track_id, const uint8_t* pixels, int stride, int width, int height, VideoFrameFormat format);
 
     bool CreateOffer();


### PR DESCRIPTION
These changes enable built-in software encoders from webrtc library itself. They fix the following items:
* take GlobalOption into account and do no pass texture frame into software encoders
* set start bitrate value for the video stream to 500000. VP8 encoder fails to start for webrtc-dotnet-web-demo with default value 300000. The start bitrate is a part of GlobalOptions so this value can be adjusted.