### PR TITLE
improve Windows 7 compatibility of web-demo project

### DIFF
--- a/webrtc-dotnet-web-demo/RtcRenderingServer.cs
+++ b/webrtc-dotnet-web-demo/RtcRenderingServer.cs
@@ -24,13 +24,22 @@ namespace WonderMediaProductions.WebRtc
         const int VideoFrameHeight = 1080/2;
         const int VideoFrameRate = 60;
 
+        static RtcRenderingServer()
+        {
+            var options = new GlobalOptions
+                          {
+                              MinimumLogLevel = TraceLevel.Info
+                          };
+            bool Windows8OrLater = Environment.OSVersion.Version >= new Version(6, 2);
+            if (!Windows8OrLater)
+            {
+                options.ForceSoftwareVideoEncoder = true;
+            }
+            PeerConnection.Configure(options);
+        }
+
         private static IRenderer CreateRenderer(ObservableVideoTrack videoTrack, ILogger logger)
         {
-            PeerConnection.Configure(new GlobalOptions
-            {
-                MinimumLogLevel = TraceLevel.Info
-            });
-
             bool isWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
             bool supportsNvEnc = PeerConnection.SupportsHardwareTextureEncoding;
 


### PR DESCRIPTION
These changes make webrtc-dotnet-web-demo running on Windows 7 using webrtc library software encoders.