### PR TITLE
convert decoded frames to ARGB using existing webrtc codebase

### DIFF
--- a/webrtc-dotnet/GlobalOptions.cs
+++ b/webrtc-dotnet/GlobalOptions.cs
@@ -12,6 +12,8 @@ namespace WonderMediaProductions.WebRtc
         public bool UseFakeEncoders = false;
         public bool UseFakeDecoders = false;
 
+        public bool UseArgbIncomingFrames = false;
+
         public TraceLevel MinimumLogLevel = TraceLevel.Verbose;
         public bool LogToStandardError = true;
         public bool LogToDebugOutput = false;

--- a/webrtc-dotnet/Native.cs
+++ b/webrtc-dotnet/Native.cs
@@ -161,6 +161,14 @@ namespace WonderMediaProductions.WebRtc
             VideoFrameCallback callback);
 
         [DllImport(DllPath, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern bool RegisterLocalArgbVideoFrameReady(IntPtr connection,
+            VideoFrameCallback callback);
+
+        [DllImport(DllPath, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern bool RegisterRemoteArgbVideoFrameReceived(IntPtr connection,
+            VideoFrameCallback callback);
+
+        [DllImport(DllPath, CallingConvention = CallingConvention.Cdecl)]
         internal static extern bool RegisterOnLocalSdpReadyToSend(IntPtr connection,
             LocalSdpReadyToSendCallback callback);
 

--- a/webrtc-dotnet/ObservablePeerConnection.cs
+++ b/webrtc-dotnet/ObservablePeerConnection.cs
@@ -17,6 +17,7 @@ namespace WonderMediaProductions.WebRtc
 
 		private readonly Subject<DataMessage> _receivedDataStream = new Subject<DataMessage>();
         private readonly Subject<VideoFrame> _receivedVideoStream = new Subject<VideoFrame>();
+        private readonly Subject<VideoFrame> _receivedArgbVideoStream = new Subject<VideoFrame>();
         private readonly Subject<VideoFrameMessage> _localVideoFrameProcessedStream = new Subject<VideoFrameMessage>();
         private readonly Subject<RemoteTrackChange> _remoteTrackChangeStream = new Subject<RemoteTrackChange>();
         private readonly Subject<string> _failureMessageStream = new Subject<string>();
@@ -28,6 +29,7 @@ namespace WonderMediaProductions.WebRtc
 
         public IObservable<DataMessage> ReceivedDataStream => _receivedDataStream;
         public IObservable<VideoFrame> ReceivedVideoStream => _receivedVideoStream;
+        public IObservable<VideoFrame> ReceivedArgbVideoStream => _receivedArgbVideoStream;
 
         public IObservable<RemoteTrackChange> RemoteTrackChangeStream => _remoteTrackChangeStream;
 
@@ -41,6 +43,7 @@ namespace WonderMediaProductions.WebRtc
 	        _disposables.Add(_localIceCandidateStream);
 	        _disposables.Add(_receivedDataStream);
 	        _disposables.Add(_receivedVideoStream);
+	        _disposables.Add(_receivedArgbVideoStream);
 	        _disposables.Add(_localVideoFrameProcessedStream);
 	        _disposables.Add(_remoteTrackChangeStream);
         }
@@ -89,6 +92,9 @@ namespace WonderMediaProductions.WebRtc
 
             RemoteVideoFrameReceived += (pc, frame) => 
                 _receivedVideoStream.TryOnNext(frame);
+
+            RemoteArgbVideoFrameReceived += (pc, frame) =>
+                _receivedArgbVideoStream.TryOnNext(frame);
 
             LocalVideoFrameProcessed += (pc, trackId, pixels, isEncoded) =>
                 _localVideoFrameProcessedStream.TryOnNext(new VideoFrameMessage(trackId, pixels, isEncoded));

--- a/webrtc-native/NativeInterface.cpp
+++ b/webrtc-native/NativeInterface.cpp
@@ -404,6 +404,18 @@ extern "C"
         return true;
     }
 
+    WEBRTC_PLUGIN_API bool RegisterLocalArgbVideoFrameReady(PeerConnection* connection, IncomingVideoFrameCallback callback)
+    {
+        connection->RegisterOnLocalArgbFrameReady(callback);
+        return true;
+    }
+
+    WEBRTC_PLUGIN_API bool RegisterRemoteArgbVideoFrameReceived(PeerConnection* connection, IncomingVideoFrameCallback callback)
+    {
+        connection->RegisterOnRemoteArgbFrameReady(callback);
+        return true;
+    }
+
     WEBRTC_PLUGIN_API bool RegisterOnLocalDataChannelReady(PeerConnection* connection, LocalDataChannelReadyCallback callback)
     {
         connection->RegisterOnLocalDataChannelReady(callback);

--- a/webrtc-native/PeerConnection.cpp
+++ b/webrtc-native/PeerConnection.cpp
@@ -201,6 +201,22 @@ void PeerConnection::RegisterOnRemoteI420FrameReady(IncomingVideoFrameCallback c
 #endif
 }
 
+void PeerConnection::RegisterOnLocalArgbFrameReady(IncomingVideoFrameCallback callback) const
+{
+#ifdef HAS_LOCAL_VIDEO_OBSERVER
+    if (local_video_observer_)
+        local_video_observer_->SetArgbVideoCallback(callback);
+#endif
+}
+
+void PeerConnection::RegisterOnRemoteArgbFrameReady(IncomingVideoFrameCallback callback) const
+{
+#ifdef HAS_REMOTE_VIDEO_OBSERVER
+    if (remote_video_observer_)
+        remote_video_observer_->SetArgbVideoCallback(callback);
+#endif
+}
+
 void PeerConnection::RegisterOnLocalDataChannelReady(LocalDataChannelReadyCallback callback)
 {
     OnLocalDataChannelReady = callback;

--- a/webrtc-native/PeerConnection.h
+++ b/webrtc-native/PeerConnection.h
@@ -39,10 +39,11 @@ public:
     bool SendData(const char* label, const uint8_t* data, int length, bool is_binary);
     bool RemoveDataChannel(const char* label);
 
-
     // Register callback functions.
     void RegisterOnLocalI420FrameReady(IncomingVideoFrameCallback callback) const;
     void RegisterOnRemoteI420FrameReady(IncomingVideoFrameCallback callback) const;
+    void RegisterOnLocalArgbFrameReady(IncomingVideoFrameCallback callback) const;
+    void RegisterOnRemoteArgbFrameReady(IncomingVideoFrameCallback callback) const;
     void RegisterOnLocalDataChannelReady(LocalDataChannelReadyCallback callback);
     void RegisterOnDataFromDataChannelReady(DataAvailableCallback callback);
     void RegisterOnFailure(FailureCallback callback);

--- a/webrtc-native/VideoObserver.cpp
+++ b/webrtc-native/VideoObserver.cpp
@@ -8,54 +8,104 @@ void VideoObserver::SetVideoCallback(IncomingVideoFrameCallback callback)
     OnIncomingVideoFrame = callback;
 }
 
+void VideoObserver::SetArgbVideoCallback(IncomingVideoFrameCallback callback)
+{
+    std::lock_guard<std::mutex> lock(mutex);
+    OnIncomingArgbVideoFrame = callback;
+}
+
 void VideoObserver::OnFrame(const webrtc::VideoFrame& frame)
 {
     std::unique_lock<std::mutex> lock(mutex);
-    if (!OnIncomingVideoFrame)
+    if (!OnIncomingVideoFrame && !OnIncomingArgbVideoFrame)
         return;
 
-    rtc::scoped_refptr<webrtc::VideoFrameBuffer> buffer(
-        frame.video_frame_buffer());
-
-    switch (buffer->type())
-    {
-    case webrtc::VideoFrameBuffer::Type::kI420A:
-    {
-        // The buffer has alpha channel.
-        webrtc::I420ABufferInterface* i420a_buffer = buffer->GetI420A();
-
-        OnIncomingVideoFrame(nullptr,
-            i420a_buffer->DataY(), i420a_buffer->DataU(),
-            i420a_buffer->DataV(), i420a_buffer->DataA(),
-            i420a_buffer->StrideY(), i420a_buffer->StrideU(),
-            i420a_buffer->StrideV(), i420a_buffer->StrideA(),
-            frame.width(), frame.height(), frame.timestamp_us());
-    }
-    break;
-
-    case webrtc::VideoFrameBuffer::Type::kNative:
+    const int width = frame.width();
+    const int height = frame.height();
+    rtc::scoped_refptr<webrtc::VideoFrameBuffer> buffer(frame.video_frame_buffer());
+    if (buffer->type() == webrtc::VideoFrameBuffer::Type::kNative)
     {
         const auto native_buffer = dynamic_cast<webrtc::NativeVideoBuffer*>(buffer.get());
         if (native_buffer)
         {
-            OnIncomingVideoFrame(native_buffer->texture(),
-                nullptr, nullptr, nullptr, nullptr,
-                0, 0, 0, 0,
-                frame.width(), frame.height(), frame.timestamp_us());
-            break;
+            if (OnIncomingVideoFrame)
+            {
+                OnIncomingVideoFrame(native_buffer->texture(),
+                    nullptr, nullptr, nullptr, nullptr,
+                    0, 0, 0, 0,
+                    width, height, frame.timestamp_us());
+            }
+            if (OnIncomingArgbVideoFrame)
+            {
+                OnIncomingArgbVideoFrame(native_buffer->texture(),
+                    nullptr, nullptr, nullptr, nullptr,
+                    0, 0, 0, 0,
+                    width, height, frame.timestamp_us());
+            }
+            return;
         }
-        // goto default:
     }
 
-    default:
+    if (buffer->type() == webrtc::VideoFrameBuffer::Type::kI420A)
     {
-        rtc::scoped_refptr<webrtc::I420BufferInterface> i420_buffer = buffer->ToI420();
+        auto i420a_buffer = buffer->GetI420A();
+        if (OnIncomingVideoFrame)
+        {
+            OnIncomingVideoFrame(nullptr,
+                i420a_buffer->DataY(), i420a_buffer->DataU(),
+                i420a_buffer->DataV(), i420a_buffer->DataA(),
+                i420a_buffer->StrideY(), i420a_buffer->StrideU(),
+                i420a_buffer->StrideV(), i420a_buffer->StrideA(),
+                width, height, frame.timestamp_us());
+        }
+        if (OnIncomingArgbVideoFrame)
+        {
+            const int stride = width * 4;
+            std::vector<byte> pixels(stride * height);
+            libyuv::I420AlphaToARGB(i420a_buffer->DataY(), i420a_buffer->StrideY(),
+                i420a_buffer->DataU(), i420a_buffer->StrideU(),
+                i420a_buffer->DataV(), i420a_buffer->StrideV(),
+                i420a_buffer->DataA(), i420a_buffer->StrideA(),
+                pixels.data(), stride, width, height, 0);
+            OnIncomingArgbVideoFrame(pixels.data(),
+                nullptr, nullptr, nullptr, nullptr,
+                0, 0, 0, 0,
+                width, height, frame.timestamp_us());
+        }
+        return;
+    }
+    rtc::scoped_refptr<webrtc::I420BufferInterface> i420_buffer_holder;
+    webrtc::I420BufferInterface* i420_buffer;
+    if (buffer->type() == webrtc::VideoFrameBuffer::Type::kI420)
+    {
+        i420_buffer = buffer->GetI420();
+    }
+    else
+    {
+        i420_buffer_holder = buffer->ToI420();
+        i420_buffer = i420_buffer_holder.get();
+    }
+
+    if (OnIncomingVideoFrame)
+    {
         OnIncomingVideoFrame(nullptr,
             i420_buffer->DataY(), i420_buffer->DataU(),
             i420_buffer->DataV(), nullptr, i420_buffer->StrideY(),
             i420_buffer->StrideU(), i420_buffer->StrideV(), 0,
-            frame.width(), frame.height(), frame.timestamp_us());
+            width, height, frame.timestamp_us());
     }
-    break;
+
+    if (OnIncomingArgbVideoFrame)
+    {
+        const int stride = width * 4;
+        std::vector<byte> pixels(stride * height);
+        libyuv::I420ToARGB(i420_buffer->DataY(), i420_buffer->StrideY(),
+            i420_buffer->DataU(), i420_buffer->StrideU(),
+            i420_buffer->DataV(), i420_buffer->StrideV(),
+            pixels.data(), stride, width, height);
+        OnIncomingArgbVideoFrame(pixels.data(),
+            nullptr, nullptr, nullptr, nullptr,
+            0, 0, 0, 0,
+            width, height, frame.timestamp_us());
     }
 }

--- a/webrtc-native/VideoObserver.h
+++ b/webrtc-native/VideoObserver.h
@@ -9,6 +9,7 @@ public:
     ~VideoObserver() = default;
 
     void SetVideoCallback(IncomingVideoFrameCallback callback);
+    void SetArgbVideoCallback(IncomingVideoFrameCallback callback);
 
 protected:
     // VideoSinkInterface implementation
@@ -16,5 +17,6 @@ protected:
 
 private:
     IncomingVideoFrameCallback OnIncomingVideoFrame = nullptr;
+    IncomingVideoFrameCallback OnIncomingArgbVideoFrame = nullptr;
     std::mutex mutex;
 };


### PR DESCRIPTION
I'm trying to integrate webrtc-dotnet-core into our project and found useful to link existing libyuv code from webrtc to convert decoded frames to ARGB. Thus no third-party with the similar functionality is needed. The conversion and callback are optional and enabled by GlobalOptions to avoid possible CPU cycles waste. 